### PR TITLE
fix macro name conflict

### DIFF
--- a/ntuthesis.cls
+++ b/ntuthesis.cls
@@ -37,9 +37,9 @@
 \DeclareRobustCommand{\author}[2]{\gdef\@authoren{#1}\gdef\@authorzh{#2}}
 \DeclareRobustCommand{\studentid}[1]{\gdef\@studentid{#1}}
 \DeclareRobustCommand{\advisor}[2]{\gdef\@advisoren{#1}\gdef\@advisorzh{#2}}
-\DeclareRobustCommand{\year}[2]{\gdef\@yearen{#1}\gdef\@yearzh{#2}}
-\DeclareRobustCommand{\month}[2]{\gdef\@monthen{#1}\gdef\@monthzh{#2}}
-\DeclareRobustCommand{\day}[1]{\gdef\@day{#1}}
+\DeclareRobustCommand{\defenseyear}[2]{\gdef\@yearen{#1}\gdef\@yearzh{#2}}
+\DeclareRobustCommand{\defensemonth}[2]{\gdef\@monthen{#1}\gdef\@monthzh{#2}}
+\DeclareRobustCommand{\defenseday}[1]{\gdef\@day{#1}}
 \DeclareRobustCommand{\abstractname}[2]{\gdef\@abstractnameen{#1}\gdef\@abstractnamezh{#2}}
 \DeclareRobustCommand{\acknowledgements}[2]{\gdef\@acknowledgementsen{#1}\gdef\@acknowledgementszh{#2}}
 

--- a/ntuvars.tex
+++ b/ntuvars.tex
@@ -15,6 +15,6 @@
 \author{Tz-Huan Huang}{黃子桓}
 \studentid{R94922044}
 \advisor{Yung-Yu Chuang, Ph.D.}{莊永裕 博士}
-\year{2007}{96}
-\month{June}{6}
-\day{28}
+\defenseyear{2007}{96}
+\defensemonth{June}{6}
+\defenseday{28}


### PR DESCRIPTION
It seems that `\year` is a predefined TeX macro. Redefining it causes a confliction in some packages.
ref. http://tex.stackexchange.com/questions/91262/conflict-between-tikz-and-university-thesis-class-file

To be consistent, I also modify `\month` and `\day`.