### PR TITLE
Add keywords and PDF properties supports

### DIFF
--- a/abstract.tex
+++ b/abstract.tex
@@ -15,6 +15,9 @@
 我們利用這些模型來量化評估五個使用者感興趣區域偵測演算法，
 此資料集也可更進一步作為基於學習理論演算法的測試資料，
 因此使基於學習理論的偵測演算法成為可能。
+
+\bigbreak
+\noindent \textbf{關鍵字：}{\, \makeatletter \@keywordszh \makeatother}
 \end{abstractzh}
 
 \begin{abstracten}
@@ -34,6 +37,9 @@ models. We use these models to evaluate five ROI detection
 algorithms quantitatively. Furthermore, by using the benchmark as
 training data, learning-based ROI detection algorithms become
 viable.
+
+\bigbreak
+\noindent \textbf{Keywords:}{\, \makeatletter \@keywordsen \makeatother}
 \end{abstracten}
 
 \begin{comment}

--- a/ntuthesis.cls
+++ b/ntuthesis.cls
@@ -45,6 +45,7 @@
 \DeclareRobustCommand{\abstractname}[2]{\gdef\@abstractnameen{#1}\gdef\@abstractnamezh{#2}}
 \DeclareRobustCommand{\acknowledgements}[2]{\gdef\@acknowledgementsen{#1}\gdef\@acknowledgementszh{#2}}
 \DeclareRobustCommand{\doi}[1]{\gdef\@doi{#1}}
+\DeclareRobustCommand{\keywords}[2]{\gdef\@keywordsen{#1}\gdef\@keywordszh{#2}}
 
 \abstractname{Abstract}{摘要}
 \acknowledgements{Acknowledgements}{誌謝}

--- a/ntuvars.tex
+++ b/ntuvars.tex
@@ -19,3 +19,4 @@
 \defensemonth{June}{6}
 \defenseday{28}
 \doi{doi:10.6342/NTU2017XXXXX}
+\keywords{keyword}{關鍵字}

--- a/thesis.tex
+++ b/thesis.tex
@@ -7,6 +7,7 @@
 \usepackage{graphicx}
 \usepackage{array}
 \usepackage{wallpaper} 
+\usepackage{hyperref}
 
 % Using the tex-text mapping for ligatures etc.
 \defaultfontfeatures{Mapping=tex-text}
@@ -25,6 +26,17 @@
 \ifdefined\withdoi
   \insertdoi
 \fi
+
+\makeatletter
+\AtBeginDocument{
+  \hypersetup{
+    pdftitle={\@titleen},
+    pdfauthor={\@authoren},
+    pdfsubject={\@typeen{} \@classen},
+    pdfkeywords={\@keywordsen}
+  }
+}
+\makeatother
 
 % Your information goes here
 \input{ntuvars}


### PR DESCRIPTION
There are the codes I've modified and used in my dissertation.

1) The keywords fields (en and zh) have been added in _abstract.tex_. Associated settings were also added in _ntuthesis.cls_ and _ntuvars.tex_.
2) PDF properties support has been added via the hyperref package. With this patch, title, author, subject, and keywords data will be filled into properties of the generated PDF.