### PR TITLE
updated watermark to overlay

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -8,6 +8,8 @@
 \usepackage{array}
 \usepackage{wallpaper} 
 \usepackage{hyperref}
+\usepackage[printwatermark]{xwatermark}
+\usepackage{graphicx}
 
 % Using the tex-text mapping for ligatures etc.
 \defaultfontfeatures{Mapping=tex-text}
@@ -17,9 +19,7 @@
 \setCJKmainfont{標楷體}
 
 \ifdefined\withwatermark
-  \CenterWallPaper{0.174}{watermark.pdf}
-  \setlength{\wpXoffset}{6.1725cm}
-  \setlength{\wpYoffset}{10.5225cm}
+  \newwatermark*[allpages,xpos=6.1725cm,ypos=10.5225cm,scale=0.5]{\includegraphics{watermark.pdf}}
 \fi
 
 % digital object identifier


### PR DESCRIPTION
Old watermark will be covered by figures with white background.
New watermark will overlay figures.

Old:
![screen shot 2018-07-31 at 4 40 46 am](https://user-images.githubusercontent.com/22386493/43422339-fc711c94-947b-11e8-8bc4-509fadf8716e.png)

New:
![screen shot 2018-07-31 at 4 40 03 am](https://user-images.githubusercontent.com/22386493/43422340-fc9e94da-947b-11e8-9233-b47080f089e3.png)
