### PR TITLE
add flag FIRSTPAGE and adjust the opacity of watermark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,12 @@ ifdef CERTIFICATION
 TEXFLAG+="\def\withcertification{1} "
 endif
 
+ifdef FIRSTPAGE
+TEXFLAG+="\def\firstpage{1} "
+else
+TEXFLAG+="\def\excludefirstpage{1} "
+endif
+
 TEXFLAG+="\input{$(MAIN)}"
 
 $(MAIN).pdf: *.tex ntuthesis.cls

--- a/thesis.tex
+++ b/thesis.tex
@@ -11,6 +11,7 @@
 \usepackage[printwatermark]{xwatermark}
 \usepackage{graphicx}
 \usepackage{pdfpages}
+\usepackage{tikz}
 
 % Using the tex-text mapping for ligatures etc.
 \defaultfontfeatures{Mapping=tex-text}
@@ -18,6 +19,20 @@
 % Set the default fonts
 \setmainfont{Times New Roman}
 \setCJKmainfont{標楷體}
+
+\ifdefined\firstpage
+
+  \ifdefined\withwatermark
+    \newsavebox\mybox
+    \savebox\mybox{\tikz[opacity=0.5]\node{\includegraphics{watermark.pdf}};}
+    \newwatermark*[allpages,xpos=6.1725cm,ypos=10.5225cm,scale=0.5]{\usebox\mybox}
+  \fi
+
+  % digital object identifier
+  \ifdefined\withdoi
+    \insertdoi
+  \fi
+\fi
 
 \makeatletter
 \AtBeginDocument{
@@ -39,13 +54,18 @@
 
 \makecover
 
-\ifdefined\withwatermark
-  \newwatermark*[allpages,xpos=6.1725cm,ypos=10.5225cm,scale=0.5]{\includegraphics{watermark.pdf}}
-\fi
+\ifdefined\excludefirstpage
 
-% digital object identifier
-\ifdefined\withdoi
-  \insertdoi
+  \ifdefined\withwatermark
+    \newsavebox\mybox
+    \savebox\mybox{\tikz[opacity=0.5]\node{\includegraphics{watermark.pdf}};}
+    \newwatermark*[allpages,xpos=6.1725cm,ypos=10.5225cm,scale=0.5]{\usebox\mybox}
+  \fi
+
+  % digital object identifier
+  \ifdefined\withdoi
+    \insertdoi
+  \fi
 \fi
 
 \ifdefined\withcertification


### PR DESCRIPTION
這個 PR 做了以下改動:

1. 因為上傳電子論文和送去影印店裝訂時的需求不同，因此新增了一個 argument `FIRSTPAGE` 到 Makefile 裡，功能是用來決定封面要不要有浮水印和DOI，如果本來就沒有加浮水印或DOI則不影響。使用時機如下:
(i) `make WATERMARK=1 DOI=1 FIRSTPAGE=1`: 封面有浮水印和DOI，這個版本可以用來上傳電子學位論文到圖書館(封面一定要有浮水印和DOI)。
(ii)`make WATERMARK=1 DOI=1`: 送去影印店裝訂時的封面不能有浮水印和DOI，因此要用這個版本。

2. 調整浮水印的不透明度成 50%，以符合學校規定。
